### PR TITLE
Properly enable sanitizer runtime checks if desired, Enable them in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   # ===== Set up NRGLjubljana and test
   - cd $TRAVIS_BUILD_DIR
   - mkdir build && cd build
-  - cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR
+  - cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DASAN=ON -DUBSAN=ON
   - export CTEST_OUTPUT_ON_FAILURE=1
   - make -j2 && make test
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,15 +117,20 @@ find_package(GMP REQUIRED)
 install(TARGETS gmp EXPORT nrgljubljana-targets)
 
 # Dynamic Analyzer Checks
+
 option(ASAN OFF "Compile library and executables with LLVM Address Sanitizer")
 option(UBSAN OFF "Compile library and executables with LLVM Undefined Behavior Sanitizer")
 
 if(ASAN)
-  find_package(sanitizer REQUIRED "asan")
+  if(NOT TARGET asan)
+    find_package(sanitizer REQUIRED "asan")
+  endif()
   install(TARGETS asan EXPORT nrgljubljana-targets)
 endif()
 if(UBSAN)
-  find_package(sanitizer REQUIRED "ubsan")
+  if(NOT TARGET ubsan)
+    find_package(sanitizer REQUIRED "ubsan")
+  endif()
   install(TARGETS ubsan EXPORT nrgljubljana-targets)
 endif()
 

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -14,7 +14,11 @@ target_compile_definitions(nrgljubljana_c PUBLIC
 				$<$<CONFIG:Debug>:NRGLJUBLJANA_DEBUG>
 )
 
-target_link_libraries(nrgljubljana_c PUBLIC openmp boost blas_lapack gmp)
+# Link dependencies
+target_link_libraries(nrgljubljana_c PUBLIC openmp boost blas_lapack gmp
+  $<$<BOOL:${ASAN}>:asan>
+  $<$<BOOL:${UBSAN}>:ubsan>
+)
 
 # Compile nrg executable
 add_executable(nrg nrg.cc)


### PR DESCRIPTION
This commit adjusts cmake to not define the sanitizer library targets `asan` and `ubsan`
if they are already defined by the parent project.
Also, it will enable the sanitizer runtime checks in the travis build.

The sanitizer runtime checks are currently failing due to an implementation detail in `boost/serialization/singleton.hpp` where a `const &` is binding to a nullptr in a member initialization.
I see the following error for all tests
```
1: /cm/shared/sw/pkg/devel/boost/1.70-gcc7-openmpi2/include/boost/serialization/singleton.hpp:181:13: runtime error: reference binding to null pointer of type 'const boost::serialization::extended_type_info_typeid<boost::numeric::ublas::vector<double, boost::numeric::ublas::unbounded_array<double, std::__1::allocator<double> > > >'
1:     #0 0x16b1aed in boost::serialization::singleton<boost::serialization::extended_type_info_typeid<boost::numeric::ublas::vector<double, boost::numeric::ublas::unbounded_array<double, std::__1::allocator<double> > > > >::get_instance() /cm/shared/sw/pkg/devel/boost/1.70-gcc7-openmpi2/include/boost/serialization/singleton.hpp:181:9
1:     #1 0x4ca182 in __cxx_global_var_init.2778 /cm/shared/sw/pkg/devel/boost/1.70-gcc7-openmpi2/include/boost/serialization/singleton.hpp:207:36                                                                                                                              
1:     #2 0x1716d8c in __libc_csu_init (/cache/dropbox/Dropbox (Simons Foundation)/Coding/nrgljubljana/build/c++/nrg+0x1716d8c)
1:     #3 0x7f09c7f2b424 in __libc_start_main (/lib64/libc.so.6+0x22424)
1:     #4 0x4d9574 in _start (/cache/dropbox/Dropbox (Simons Foundation)/Coding/nrgljubljana/build/c++/nrg+0x4d9574)
```

This problem seems to be known for some time unfortunately, see [here](https://lists.boost.org/boost-bugs/2015/04/40748.php) where they give a minimal example to reproduce the behavior.

It would be great if it would be possible to work around this in one way or the other given that the
sanitizer runtime checks provide very valueable runtime information.