### PR TITLE
[cmake] Check if fmt is already a target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,10 @@ CPMAddPackage(
 )
 
 # fmt
-CPMAddPackage("gh:fmtlib/fmt#11.0.2")
+# Check if fmt is already a target; important when using as an outside library in nrgljubljana_interface
+if (NOT TARGET fmt::fmt)
+  CPMAddPackage("gh:fmtlib/fmt#11.0.2")
+endif()
 
 # range-v3
 CPMAddPackage("gh:ericniebler/range-v3#0.12.0")


### PR DESCRIPTION
Check if fmt library is already a target. Important when using nrgljubljana in nrgljubljana_interface to avoid clashes with fmt library imported by TRIQS package.