### PR TITLE
[cpp] Disable pretty printing when writing to files

### DIFF
--- a/c++/core.hpp
+++ b/c++/core.hpp
@@ -120,10 +120,10 @@ auto do_diag(const Step &step, const Operators<S> &operators, const Coef<S> &coe
       break;
     }
     catch (NotEnough &e) {
-      fmt::print(fmt::emphasis::bold | fg(fmt::color::yellow), "Insufficient number of states computed.\n");
+      color_print(P.pretty_out, fmt::emphasis::bold | fg(fmt::color::yellow), "Insufficient number of states computed.\n");
       if (!(step.nrg() && P.restart)) break;
       diagratio = std::min(diagratio * P.restartfactor, 1.0);
-      fmt::print(fmt::emphasis::bold | fg(fmt::color::yellow), "\nRestarting this iteration step. diagratio={}\n\n", diagratio);
+      color_print(P.pretty_out, fmt::emphasis::bold | fg(fmt::color::yellow), "\nRestarting this iteration step. diagratio={}\n\n", diagratio);
     }
   }
   return diag;

--- a/c++/io.hpp
+++ b/c++/io.hpp
@@ -19,8 +19,8 @@ namespace NRG {
 
 template <typename... Args>
     auto color_print(bool enable_color, const fmt::text_style& ts, fmt::format_string<Args...> format_str, Args&&... args) {
-      return enable_color ? print(stdout, ts, format_str, std::forward<Args>(args)...)
-         : print(stdout, fmt::text_style{}, format_str, std::forward<Args>(args)...);
+      return enable_color ? fmt::print(stdout, ts, format_str, std::forward<Args>(args)...)
+         : fmt::print(stdout, fmt::text_style{}, format_str, std::forward<Args>(args)...);
 }
 
 using namespace fmt::literals;

--- a/c++/nrg-general.hpp
+++ b/c++/nrg-general.hpp
@@ -119,7 +119,7 @@ public:
       docalc0(step, operators, diag0, stats, output, oprecalc, Sym.get(), mt, P);
     auto diag = P.ZBW() ? nrg_ZBW(step, operators, stats, diag0, output, store, store_all, oprecalc, Sym.get(), mt, P)
                         : nrg_loop(step, operators, coef, stats, diag0, output, store, store_all, oprecalc, Sym.get(), eng.get(), mt, P);
-    fmt::print(fmt::emphasis::bold | fg(fmt::color::red), FMT_STRING("\nTotal energy: {:.18}\n"), stats.total_energy);
+    color_print(P.pretty_out, fmt::emphasis::bold | fg(fmt::color::red), FMT_STRING("\nTotal energy: {:.18}\n"), stats.total_energy);
     stats.GS_energy = stats.total_energy;
     if (step.nrg()) {
       store.shift_abs_energies(stats.GS_energy);

--- a/c++/output.hpp
+++ b/c++/output.hpp
@@ -51,7 +51,7 @@ class ExpvOutput {
      F << std::endl;
      if (cout_dump)
        for (const auto &op: fields)
-         fmt::print(fmt::emphasis::bold | fg(fmt::color::red), "<{}>={}\n", op, formatted_output(m[op], P)); // NOTE: real and imaginary part shown
+         color_print(P.pretty_out, fmt::emphasis::bold | fg(fmt::color::red), "<{}>={}\n", op, formatted_output(m[op], P)); // NOTE: real and imaginary part shown
    }
    ExpvOutput(const std::string &fn, std::map<std::string, t_expv> &m,
               std::list<std::string> fields, const Params &P) : m(m), fields(std::move(fields)), P(P) {

--- a/c++/spectrum.hpp
+++ b/c++/spectrum.hpp
@@ -83,7 +83,7 @@ class SpectrumRealFreq {
      mergeNN2half(fsneg, cs.sneg, step);
    }
    void save() {
-     fmt::print(fmt::emphasis::bold, "Spectrum: {} {} -> ", name, algoname); // savebins() & continuous() append the filenames
+     color_print(P.pretty_out, fmt::emphasis::bold, "Spectrum: {} {} -> ", name, algoname); // savebins() & continuous() append the filenames
      trim();
      if (P.savebins) savebins();
      if (P.broaden) continuous();
@@ -224,7 +224,7 @@ class GFMatsubara {
      results.merge(cm.m);
    }
    void save() {
-     fmt::print(fmt::emphasis::bold, "GF Matsubara: {} {} -> {}\n", name, algoname, filename);
+     color_print(P.pretty_out, fmt::emphasis::bold, "GF Matsubara: {} {} -> {}\n", name, algoname, filename);
      results.save(safe_open(filename + ".dat"), P.prec_xy);
    }
 };
@@ -242,7 +242,7 @@ class TempDependence {
      std::copy(ctd.v.cbegin(), ctd.v.cend(), std::back_inserter(results));
    }
    void save() {
-     fmt::print(fmt::emphasis::bold, "Temperature dependence: {} {} -> {}\n", name, algoname, filename);
+     color_print(P.pretty_out, fmt::emphasis::bold, "Temperature dependence: {} {} -> {}\n", name, algoname, filename);
      ranges::sort(results, sortfirst());
      results.save(safe_open(filename + ".dat"), P.prec_xy, P.reim);
    }

--- a/c++/step.hpp
+++ b/c++/step.hpp
@@ -46,7 +46,7 @@ class Step {
      auto info = fmt::format(" ***** [{}] Iteration {}/{} (scale {}) ***** ", runtype == RUNTYPE::NRG ? "NRG"s : "DM"s,
                              ndxN+1, int(P.Nmax), energyscale());
      info += P.substeps ? fmt::format(" step {} substep {}", NM().first+1, NM().second+1) : "";
-     fmt::print(fmt::emphasis::bold, "\n{}\n", info);
+     color_print(P.pretty_out, fmt::emphasis::bold, "\n{}\n", info);
    }
    void set_ZBW() noexcept {
      trueN = int(P.Ninit) - 1; // if Ninit=0, trueN will be -1 (this is the only exceptional case)


### PR DESCRIPTION
This was (unintentionally) removed in PR #19. Restores previous functionality of disabling fmt library color/bold printing when redirecting output to files.