### PR TITLE
CMake Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,9 @@
 # ##############################################################################
 
 cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
-if(POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-if(POLICY CMP0144)
-  cmake_policy(SET CMP0144 NEW)
+cmake_policy(VERSION ${CMAKE_VERSION})
+if(POLICY CMP0173) # CMakeFindFrameworks Availability
+  cmake_policy(SET CMP0173 OLD)
 endif()
 
 # ############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ CPMFindPackage(
 # High five library
 CPMAddPackage(
   GITHUB_REPOSITORY BlueBrain/HighFive
-  GIT_TAG v2.10.0
+  GIT_TAG v2.10.1
   OPTIONS
     "HIGHFIVE_BUILD_DOCS OFF" # Disable HighFive documentation
 )
@@ -195,7 +195,7 @@ CPMAddPackage(
 # fmt
 # Check if fmt is already a target; important when using as an outside library in nrgljubljana_interface
 if (NOT TARGET fmt::fmt)
-  CPMAddPackage("gh:fmtlib/fmt#11.0.2")
+  CPMAddPackage("gh:fmtlib/fmt#11.2.0")
 endif()
 
 # range-v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,10 +157,6 @@ set(Boost_USE_STATIC_LIBS OFF)
 find_package(Boost 1.53 REQUIRED COMPONENTS serialization mpi)
 # note: header-only libraries such as multiprecision do not need to be listed
 # as components in find_package()
-add_library(boost INTERFACE)
-target_include_directories(boost SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})
-target_link_libraries(boost INTERFACE ${Boost_LIBRARIES})
-install(TARGETS boost EXPORT nrgljubljana-targets)
 
 # GSL
 find_package(GSL REQUIRED)

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -45,7 +45,7 @@ target_compile_definitions(nrgljubljana_c PUBLIC
 )
 
 # Link dependencies
-target_link_libraries(nrgljubljana_c     PUBLIC openmp boost blas_lapack gmp dl mpi HighFive fmt::fmt-header-only range-v3 Eigen3::Eigen
+target_link_libraries(nrgljubljana_c     PUBLIC openmp Boost::headers Boost::mpi Boost::serialization blas_lapack gmp dl mpi HighFive fmt::fmt-header-only range-v3 Eigen3::Eigen
   $<$<BOOL:${ASAN}>:asan>
   $<$<BOOL:${UBSAN}>:ubsan>
 )

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -18,7 +18,7 @@ macro(add_tool exec_name)
   set_target_properties(${exec_name} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
   # Link dependencies
-  target_link_libraries(${exec_name} PRIVATE openmp boost blas_lapack gmp gsl dl HighFive fmt::fmt-header-only range-v3 Eigen3::Eigen
+  target_link_libraries(${exec_name} PRIVATE openmp Boost::boost Boost::mpi Boost::serialization blas_lapack gmp gsl dl HighFive fmt::fmt-header-only range-v3 Eigen3::Eigen
         $<$<BOOL:${ASAN}>:asan>
         $<$<BOOL:${UBSAN}>:ubsan>
   )


### PR DESCRIPTION
* Use find_package(Boost) predefined targets
* Bump version numbers for fmt and highfive
* Set cmake policies to new by default