### PR TITLE
[ghactions] Update HighFive dependency to version 3.1 and update repository location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,8 +184,8 @@ CPMFindPackage(
 
 # High five library
 CPMAddPackage(
-  GITHUB_REPOSITORY BlueBrain/HighFive
-  GIT_TAG v2.10.1
+  GITHUB_REPOSITORY highfive-devs/highfive
+  GIT_TAG v3.1.0
   OPTIONS
     "HIGHFIVE_BUILD_DOCS OFF" # Disable HighFive documentation
 )


### PR DESCRIPTION
This change is necessary to avoid cmake issues with old HighFive versions, c.f. below

```
CMake Error at /tmp/build/_deps/highfive-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.```